### PR TITLE
Create favicon-responding middleware

### DIFF
--- a/joodo/spec/joodo/middleware/favicon_spec.clj
+++ b/joodo/spec/joodo/middleware/favicon_spec.clj
@@ -1,0 +1,33 @@
+(ns joodo.middleware.favicon-spec
+  (:use
+    [speclj.core]
+    [joodo.middleware.favicon]))
+
+(describe "favicon-ignoring middleware"
+  (with updated-request (atom nil))
+  (with mock-handler
+    (fn [request]
+      (reset! @updated-request request)
+      {:status 200 :body "more processing"}))
+
+  (it "ignores favicon GET requests"
+    (let [request-data {:uri "/favicon.ico"
+                        :request-method :get}
+          handler (wrap-favicon-bouncer @mock-handler)]
+      (should= {:status 404 :headers {} :body ""}
+               (handler request-data))))
+
+  (it "processes favicon POST requests (in case that happens)"
+    (let [request-data {:uri "/favicon.ico"
+                        :request-method :post}
+          handler (wrap-favicon-bouncer @mock-handler)]
+      (should= {:status 200 :body "more processing"}
+               (handler request-data))))
+
+  (it "processes non-favicon requests"
+    (let [request-data {:uri "/someplace"
+                        :request-method :get}
+          handler (wrap-favicon-bouncer @mock-handler)]
+      (should= {:status 200 :body "more processing"}
+               (handler request-data)))))
+

--- a/joodo/src/joodo/kake/servlet.clj
+++ b/joodo/src/joodo/kake/servlet.clj
@@ -10,6 +10,7 @@
     [joodo.middleware.keyword-cookies :only (wrap-keyword-cookies)]
     [joodo.middleware.multipart-params :only (wrap-multipart-params)]
     [joodo.middleware.servlet-session :only (wrap-servlet-session)]
+    [joodo.middleware.favicon :only (wrap-favicon-bouncer)]
     [joodo.middleware.flash :only (wrap-flash)]
     [joodo.middleware.request :only (wrap-bind-request)])
   (:import
@@ -62,7 +63,8 @@
       wrap-flash
       wrap-keyword-cookies
       wrap-cookies
-      wrap-servlet-session)))
+      wrap-servlet-session
+      wrap-favicon-bouncer)))
 
 (defn extract-joodo-handler []
   (let [core-namespace (env :joodo.root.namespace)

--- a/joodo/src/joodo/middleware/favicon.clj
+++ b/joodo/src/joodo/middleware/favicon.clj
@@ -1,0 +1,14 @@
+(ns ^{:doc "This namespace is for favicon.ico requests."}
+  joodo.middleware.favicon)
+
+(defn- is-favicon-request? [request]
+  (= [:get "/favicon.ico"] [(:request-method request) (:uri request)]))
+
+(defn wrap-favicon-bouncer
+  "Responds with 404 for /favicon.ico requests."
+  [handler]
+  (fn [request]
+    (if (is-favicon-request? request)
+      {:status 404 :headers {} :body ""}
+      (handler request))))
+


### PR DESCRIPTION
By the time the request handlers get down to the Ring middleware stack, we're already past the point where static assets would have been served (that's in `joodo.kake.StaticFileFilter.java`). 

This patch makes any GET request to /favicon.ico respond immediately with a 404, rather than going through all of the routing, logging, and other middlewares that are currently being run on such requests.

So it should give a bit of a performance boost depending on what all middlewares are being used, and it also avoids extra logging that can be noisy when trying to debug things.

The only place I can imagine this going wrong would be if an app needed to dynamically specify the favicon based on clojure application logic. And that seems unlikely.
