### PR TITLE
Updated Joodo generators to emit the latest version of speclj and joodo.

### DIFF
--- a/lein-joodo/project.clj
+++ b/lein-joodo/project.clj
@@ -4,7 +4,7 @@
     (catch java.io.FileNotFoundException e
       {:version "0.9.0"
        :clojure-version "1.4.0"
-       :speclj-version "2.2.0"})))
+       :speclj-version "2.3.1"})))
 (defproject joodo/lein-joodo (:version config)
   :description "Leiningen Plugin for Joodo, a Clojure framework for web apps."
   :license {:name "The MIT License"

--- a/lein-joodo/resources/joodo/kuzushi/templates/project.clj
+++ b/lein-joodo/resources/joodo/kuzushi/templates/project.clj
@@ -6,13 +6,13 @@
   :joodo-root-namespace !-APP_NAME-!.root
 
   ; leiningen 2
-  :profiles {:dev {:dependencies [[speclj "2.2.0"]]}}
+  :profiles {:dev {:dependencies [[speclj "2.3.1"]]}}
   :test-paths ["spec/"]
   :java-source-paths ["src/"]
-  :plugins [[speclj "2.2.0"]]
+  :plugins [[speclj "2.3.1"]]
 
   ; leiningen 1
-  :dev-dependencies [[speclj "2.2.0"]]
+  :dev-dependencies [[speclj "2.3.1"]]
   :test-path "spec/"
   :java-source-path "src/"
 

--- a/lein-joodo/src/joodo/kuzushi/version.clj
+++ b/lein-joodo/src/joodo/kuzushi/version.clj
@@ -3,7 +3,7 @@
     [clojure.string :as str]))
 
 (def major 0)
-(def minor 11)
+(def minor 12)
 (def tiny 0)
 (def snapshot false)
 (def string
@@ -12,4 +12,4 @@
     (if snapshot "-SNAPSHOT" "")))
 (def summary (str "joodo/lein-joodo " string))
 
-(def joodo-version "0.11.0")
+(def joodo-version "0.12.0")


### PR DESCRIPTION
The joodo application generator was emitting older versions of joodo (v0.11) and speclj (v2.2.0) instead of the current v0.12 and v2.3.1 respectively. 

The speclj was causing the specs to fail due to obsolete code in a plugin (I don't know how to debug this in Clojure right now but the upgrade did the trick and specs work now.)
