### PR TITLE
Updates Joodo and related sub-projects to Clojure 1.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# ??
+
+* Upgraded from Clojure 1.4.0 to 1.5.0
+
 # ?
 
 * generated project updated to work with lein2 on heroku cedar

--- a/chee/project.clj
+++ b/chee/project.clj
@@ -4,7 +4,7 @@
             :url "file://LICENSE"
             :distribution :repo
             :comments "Copyright (c) 2011-2013 Micah Martin All Rights Reserved."}
-  :dependencies [[org.clojure/clojure "1.4.0"]]
+  :dependencies [[org.clojure/clojure "1.5.0"]]
   :profiles {:dev {:dependencies [[speclj "2.5.0"]]}}
   :plugins [[speclj "2.5.0"]]
   :test-paths ["spec/"]

--- a/joodo/project.clj
+++ b/joodo/project.clj
@@ -4,7 +4,7 @@
             :url "file://LICENSE"
             :distribution :repo
             :comments "Copyright (c) 2011-2013 Micah Martin All Rights Reserved."}
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.0"]
                  [ring/ring-core "1.1.7"]
                  [ring/ring-jetty-adapter "1.1.7"]
                  [compojure "1.1.5"]

--- a/lein-joodo/project.clj
+++ b/lein-joodo/project.clj
@@ -4,7 +4,7 @@
             :url "file://LICENSE"
             :distribution :repo
             :comments "Copyright (c) 2011-2013 Micah Martin All Rights Reserved."}
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.0"]
                  [filecabinet "1.0.4"]
                  [mmargs "1.2.0"]]
   :profiles {:dev {:dependencies [[speclj "2.5.0"]

--- a/lein-joodo/resources/joodo/kuzushi/templates/project.clj
+++ b/lein-joodo/resources/joodo/kuzushi/templates/project.clj
@@ -1,6 +1,6 @@
 (defproject !-APP_NAME-! "0.0.1"
   :description "A simple stand-alone webapp"
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.0"]
                  [joodo "!-JOODO_VERSION-!"]]
   :min-lein-version "2.0.0"
 


### PR DESCRIPTION
Updates Joodo, lein-joodo, chee, and the project.clj template to Clojure 1.5.0
