### PR TITLE
[chee] Refactors coerce specs; adds support for most primative Java types

### DIFF
--- a/chee/spec/chee/coerce_spec.clj
+++ b/chee/spec/chee/coerce_spec.clj
@@ -1,78 +1,299 @@
 (ns chee.coerce-spec
-  (:use [speclj.core]
-        [chee.coerce]))
+  (:require [speclj.core :refer :all]
+            [chee.matchers :refer :all]
+            [chee.coerce :refer :all]))
 
-(describe "Type Coercion"
-  (context "Integer"
-    (it "coerces a string to an integer"
-      (should= (Integer. 1) (->int "1"))
-      (should-throw IllegalArgumentException (->int "not an int")))
+(describe "chee.coerce"
 
-    (it "coerces a long to an integer"
-      (should= (Integer. 1) (->int 1)))
+  (context "java.lang.String"
 
-    (it "coerces an integer to an integer"
-      (should= (Integer. 1) (->int (Integer/parseInt "1")))))
-
-  (context "String"
     (it "coerces a string to a string"
-      (should= "thing" (->string "thing")))
+      (should=str "thing" (->string "thing")))
 
     (it "coerces a symbol to a string"
-      (should= "thing" (->string (symbol "thing"))))
+      (should=str "thing" (->string (symbol "thing"))))
 
     (it "coerces a keyword to a string"
-      (should= "thing" (->string :thing)))
+      (should=str "thing" (->string :thing)))
 
     (it "coerces a boolean to a string"
-      (should= "true" (->string true))
-      (should= "false" (->string false))))
+      (should=str "true" (->string true))
+      (should=str "false" (->string false)))
 
-  (context "Keyword"
+    (it "handles nil"
+      (should-be-nil (->string nil)))
+
+    )
+
+  (context "clojure.lang.Keyword"
+
     (it "coerces a string to a keyword"
-      (should= :thing (->keyword "thing")))
+      (should=kwd :thing (->keyword "thing")))
 
     (it "coerces a symbol to a keyword"
-      (should= :thing (->keyword (symbol "thing"))))
+      (should=kwd :thing (->keyword (symbol "thing"))))
 
     (it "coerces a keyword to a keyword"
-      (should= :thing (->keyword :thing)))
+      (should=kwd :thing (->keyword :thing)))
 
     (it "coerces a boolean to a keyword"
-      (should= :true (->keyword true))
-      (should= :false (->keyword false))))
+      (should=kwd :true (->keyword true))
+      (should=kwd :false (->keyword false)))
 
-  (context "Symbol"
+    (it "handles nil"
+      (should-be-nil (->keyword nil)))
+
+    )
+
+  (context "clojure.lang.Symbol"
+
     (with sym (symbol "thing"))
 
     (it "coerces a string to a symbol"
-      (should= @sym (->symbol "thing")))
+      (should=sym @sym (->symbol "thing")))
 
     (it "coerces a symbol to a symbol"
-      (should= @sym (->symbol (symbol "thing"))))
+      (should=sym @sym (->symbol (symbol "thing"))))
 
     (it "coerces a keyword to a symbol"
-      (should= @sym (->symbol :thing)))
+      (should=sym @sym (->symbol :thing)))
 
     (it "coerces a boolean to a symbol"
-      (should= (symbol "true") (->symbol true))
-      (should= (symbol "false") (->symbol false))))
+      (should=sym (symbol "true") (->symbol true))
+      (should=sym (symbol "false") (->symbol false)))
 
-  (context "Boolean"
+    (it "handles nil"
+      (should-be-nil (->symbol nil)))
+
+    )
+
+  (context "java.lang.Boolean"
+
     (it "coerces a string to boolean"
-      (should= true  (->bool "true"))
-      (should= false (->bool "false")))
+      (should=bool true  (->bool "true"))
+      (should=bool false (->bool "false")))
 
-    (it "coerces nil to boolean"
-      (should= false (->bool nil)))
+    (it "coerces an integer to a boolean"
+      (should=bool true  (->bool (int 1)))
+      (should=bool false (->bool (int 0))))
+
+    (it "coerces a long to a boolean"
+      (should=bool true  (->bool (long 1)))
+      (should=bool false (->bool (long 0))))
+
+    (it "coerces a big integer to a boolean"
+      (should=bool true  (->bool (BigInteger. "1")))
+      (should=bool false (->bool (BigInteger. "0"))))
 
     (it "coerces a boolean to boolean"
-      (should= true  (->bool true))
-      (should= false (->bool false)))
+      (should=bool true  (->bool true))
+      (should=bool false (->bool false)))
 
     (it "coeerces a keyword to a boolean"
-      (should= true (->bool :true))
-      (should= false (->bool :false)))
+      (should=bool true (->bool :true))
+      (should=bool false (->bool :false)))
 
     (it "coerces a symbol to a boolean"
-      (should= true (->bool (symbol "true"))))))
+      (should=bool true (->bool (symbol "true"))))
+
+    (it "handles nil"
+      (should-be-nil (->bool nil)))
+
+  )
+
+  (context "java.lang.Byte"
+
+    (it "coerces a string to a byte"
+      (should=byte (byte 1) (->byte "1"))
+      (should-throw IllegalArgumentException (->byte "not an int")))
+
+    (it "coerces a byte to a byte"
+      (should=byte (byte 1) (->byte (byte 1))))
+
+    (it "coerces a short to a byte"
+      (should=byte (byte 1) (->byte (short 1))))
+
+    (it "coerces a long to an byte"
+      (should=byte (byte 1) (->byte (long 1))))
+
+    (it "coerces an integer to a byte"
+      (should=byte (byte 1) (->byte (int 1))))
+
+    (it "coerces a big integer to a byte"
+      (should=byte (byte 1) (->byte (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->byte nil)))
+
+    )
+
+  (context "java.lang.Short"
+
+    (it "coerces a string to a short"
+      (should=short (short 1) (->short "1"))
+      (should-throw IllegalArgumentException (->short "not an int")))
+
+    (it "coerces a byte to a short"
+      (should=short (short 1) (->short (byte 1))))
+
+    (it "coerces a short to a short"
+      (should=short (short 1) (->short (short 1))))
+
+    (it "coerces an integer to a short"
+      (should=short (short 1) (->short (int 1))))
+
+    (it "coerces a long to an short"
+      (should=short (short 1) (->short (long 1))))
+
+    (it "coerces a big integer to a short"
+      (should=short (short 1) (->short (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->short nil)))
+
+    )
+
+  (context "java.lang.Integer"
+
+    (it "coerces a string to an integer"
+      (should=int (int 1) (->int "1"))
+      (should-throw IllegalArgumentException (->int "not an int")))
+
+    (it "coerces a byte to an integer"
+      (should=int (int 1) (->int (byte 1))))
+
+    (it "coerces a short to an integer"
+      (should=int (int 1) (->int (short 1))))
+
+    (it "coerces an integer to an integer"
+      (should=int (int 1) (->int (int 1))))
+
+    (it "coerces a long to an integer"
+      (should=int (int 1) (->int 1)))
+
+    (it "coerces a biginteger to an integer"
+      (should=int (int 1) (->int (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->int nil)))
+
+    )
+
+  (context "java.lang.Long"
+
+    (it "coerces a string to a long"
+      (should=long 1 (->long "1"))
+      (should-throw IllegalArgumentException (->long "not an int")))
+
+    (it "coerces a byte to a long"
+      (should=long 1 (->long (byte 1))))
+
+    (it "coerces a short to a long"
+      (should=long 1 (->long (short 1))))
+
+    (it "coerces a integer to a long"
+      (should=long 1 (->long (int 1))))
+
+    (it "coerces a long to a long"
+      (should=long 1 (->long (long 1))))
+
+    (it "coerces a big integer to a long"
+      (should=long 1 (->long (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->long nil)))
+
+    )
+
+  (context "java.lang.BigInteger"
+
+    (with big-int (BigInteger. "1"))
+
+    (it "coerces a string to a big int"
+      (should=biginteger @big-int (->biginteger "1"))
+      (should-throw IllegalArgumentException (->biginteger "not an int")))
+
+    (it "coerces a byte to a big int"
+      (should=biginteger @big-int (->biginteger (byte 1))))
+
+    (it "coerces a short to a big int"
+      (should=biginteger @big-int (->biginteger (short 1))))
+
+    (it "coerces a integer to a big int"
+      (should=biginteger @big-int (->biginteger (int 1))))
+
+    (it "coerces a long to a big int"
+      (should=biginteger @big-int (->biginteger (long 1))))
+
+    (it "coerces a big integer to a big int"
+      (should=biginteger @big-int (->biginteger (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->biginteger nil)))
+
+    )
+
+  (context "java.lang.Float"
+
+    (it "coerces a string to a float"
+      (should=flt (float 1) (->float "1"))
+      (should-throw IllegalArgumentException (->float "not an int")))
+
+    (it "coerces a byte to a float"
+      (should=flt (float 1) (->float (byte 1))))
+
+    (it "coerces a short to a float"
+      (should=flt (float 1) (->float (short 1))))
+
+    (it "coerces an integer to a float"
+      (should=flt (float 1) (->float (int 1))))
+
+    (it "coerces a long to a float"
+      (should=flt (float 1) (->float (long 1))))
+
+    (it "coerces a float to a float"
+      (should=flt (float 1.0) (->float (float 1.0))))
+
+    (it "coerces a double to a float"
+      (should=flt (float 1) (->float (double 1))))
+
+    (it "coerces a big integer to a float"
+      (should=flt (float 1) (->float (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->float nil)))
+
+    )
+
+  (context "java.lang.Double"
+
+    (it "coerces a string to a double"
+      (should=dbl (double 1.2) (->double "1.2"))
+      (should-throw IllegalArgumentException (->double "not an int")))
+
+    (it "coerces a byte to a double"
+      (should=dbl (double 1) (->double (byte 1))))
+
+    (it "coerces a short to a double"
+      (should=dbl (double 1) (->double (short 1))))
+
+    (it "coerces an integer to a double"
+      (should=dbl (double 1) (->double (int 1))))
+
+    (it "coerces a long to a double"
+      (should=dbl (double 1) (->double (long 1))))
+
+    (it "coerces a float to a double"
+      (should=dbl (double 1.0) (->double (float 1.0))))
+
+    (it "coerces a double to a double"
+      (should=dbl (double 1) (->double (double 1))))
+
+    (it "coerces a big integer to a double"
+      (should=dbl (double 1) (->double (BigInteger. "1"))))
+
+    (it "handles nil"
+      (should-be-nil (->double nil)))
+
+    )
+  )

--- a/chee/spec/chee/matchers.clj
+++ b/chee/spec/chee/matchers.clj
@@ -1,0 +1,59 @@
+(ns chee.matchers
+  (:require [speclj.core :refer :all]
+            [speclj.util :refer [endl]]))
+
+(defmacro should=str [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.String ~actual-form)))
+
+(defmacro should=kwd [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a clojure.lang.Keyword ~actual-form)))
+
+(defmacro should=sym [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a clojure.lang.Symbol ~actual-form)))
+
+(defmacro should=bool [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Boolean ~actual-form)))
+
+(defmacro should=byte [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Byte ~actual-form)))
+
+(defmacro should=short [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Short ~actual-form)))
+
+(defmacro should=int [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Integer ~actual-form)))
+
+(defmacro should=long [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Long ~actual-form)))
+
+(defmacro should=biginteger [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.math.BigInteger ~actual-form)))
+
+(defmacro should=flt [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Float ~actual-form)))
+
+(defmacro should=dbl [expected-form actual-form]
+  `(do
+     (should= ~expected-form ~actual-form)
+     (should-be-a java.lang.Double ~actual-form)))
+

--- a/chee/src/chee/coerce.clj
+++ b/chee/src/chee/coerce.clj
@@ -3,9 +3,6 @@
 (defprotocol AsBoolean
   (->bool [this]))
 
-(defprotocol AsInteger
-  (->int [this]))
-
 (defprotocol AsString
   (->string [this]))
 
@@ -15,30 +12,209 @@
 (defprotocol AsSymbol
   (->symbol [this]))
 
-(extend-type java.lang.Long
+(defprotocol AsByte
+  (->byte [this]))
+
+(defprotocol AsShort
+  (->short [this]))
+
+(defprotocol AsInteger
+  (->int [this]))
+
+(defprotocol AsLong
+  (->long [this]))
+
+(defprotocol AsBigInteger
+  (->biginteger [this]))
+
+(defprotocol AsFloat
+  (->float [this]))
+
+(defprotocol AsDouble
+  (->double [this]))
+
+(extend-type java.lang.Byte
+  AsByte
+  (->byte [this] this)
+
+  AsShort
+  (->short [this] (.shortValue this))
+
   AsInteger
-  (->int [this] (.intValue this)))
+  (->int [this] (.intValue this))
+
+  AsLong
+  (->long [this] (.longValue this))
+
+  AsBigInteger
+  (->biginteger [this] (BigInteger. (str this)))
+
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
+
+(extend-type java.lang.Short
+  AsByte
+  (->byte [this] (.byteValue this))
+
+  AsShort
+  (->short [this] this)
+
+  AsInteger
+  (->int [this] (.intValue this))
+
+  AsLong
+  (->long [this] (.longValue this))
+
+  AsBigInteger
+  (->biginteger [this] (BigInteger. (str this)))
+
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
 
 (extend-type java.lang.Integer
+  AsBoolean
+  (->bool [this] (= this 1))
+
+  AsByte
+  (->byte [this] (.byteValue this))
+
+  AsShort
+  (->short [this] (.shortValue this))
+
   AsInteger
-  (->int [this] this))
+  (->int [this] this)
+
+  AsLong
+  (->long [this] (.longValue this))
+
+  AsBigInteger
+  (->biginteger [this] (BigInteger. (str this)))
+
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
+
+(extend-type java.lang.Long
+  AsBoolean
+  (->bool [this] (= this 1))
+
+  AsByte
+  (->byte [this] (.byteValue this))
+
+  AsShort
+  (->short [this] (.shortValue this))
+
+  AsInteger
+  (->int [this] (.intValue this))
+
+  AsLong
+  (->long [this] this)
+
+  AsBigInteger
+  (->biginteger [this] (BigInteger. (str this)))
+
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
+
+(extend-type java.math.BigInteger
+  AsBoolean
+  (->bool [this] (= this 1))
+
+  AsByte
+  (->byte [this] (.byteValue this))
+
+  AsShort
+  (->short [this] (.shortValue this))
+
+  AsInteger
+  (->int [this] (.intValue this))
+
+  AsLong
+  (->long [this] (.longValue this))
+
+  AsBigInteger
+  (->biginteger [this] this)
+
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
+
+(extend-type java.lang.Float
+  AsFloat
+  (->float [this] this)
+
+  AsDouble
+  (->double [this] (.doubleValue this))
+
+  )
+
+(extend-type java.lang.Double
+  AsFloat
+  (->float [this] (.floatValue this))
+
+  AsDouble
+  (->double [this] this)
+
+  )
 
 (extend-type java.lang.String
-  AsString
-  (->string [this] this)
+  AsBoolean
+  (->bool [this] (= "true" this))
 
   AsKeyword
   (->keyword [this] (keyword this))
 
-  AsBoolean
-  (->bool [this] (= "true" this))
-
-  AsInteger
-  (->int [this] (Integer/parseInt this))
+  AsString
+  (->string [this] this)
 
   AsSymbol
-  (->symbol [this] (symbol this)))
+  (->symbol [this] (symbol this))
 
+  AsByte
+  (->byte [this] (Byte. this))
+
+  AsShort
+  (->short [this] (Short. this))
+
+  AsInteger
+  (->int [this] (Integer. this))
+
+  AsLong
+  (->long [this] (Long. this))
+
+  AsBigInteger
+  (->biginteger [this] (BigInteger. this))
+
+  AsFloat
+  (->float [this] (Float. this))
+
+  AsDouble
+  (->double [this] (Double. this))
+
+  )
 (extend-type clojure.lang.Keyword
   AsString
   (->string [this] (name this))
@@ -50,7 +226,7 @@
   (->bool [this] (= :true this))
 
   AsSymbol
-  (->symbol [this] (symbol (->string this))))
+  (->symbol [this] (symbol (name this))))
 
 (extend-type clojure.lang.Symbol
   AsString
@@ -76,8 +252,40 @@
   (->keyword [this] (keyword (.toString this)))
 
   AsSymbol
-  (->symbol [this] (symbol (->string this))))
+  (->symbol [this] (symbol (.toString this))))
 
 (extend-type nil
   AsBoolean
-  (->bool [this] false))
+  (->bool [this] nil)
+
+  AsString
+  (->string [this] nil)
+
+  AsKeyword
+  (->keyword [this] nil)
+
+  AsSymbol
+  (->symbol [this] nil)
+
+  AsByte
+  (->byte [this] nil)
+
+  AsShort
+  (->short [this] nil)
+
+  AsInteger
+  (->int [this] nil)
+
+  AsLong
+  (->long [this] nil)
+
+  AsBigInteger
+  (->biginteger [this] nil)
+
+  AsFloat
+  (->float [this] nil)
+
+  AsDouble
+  (->double [this] nil)
+
+  )


### PR DESCRIPTION
This refactors the coerce specs to be grouped by type and adds support for most of the Java primitive types, save BigDecimal.
